### PR TITLE
Changing process.nextTick to setImmediate

### DIFF
--- a/lib/adapters/redis/index.js
+++ b/lib/adapters/redis/index.js
@@ -38,7 +38,7 @@ adapter.publish.prepareChannels = function() {
 
 adapter.publish.publish = function(cli) {
   return function(name, chunk, next) {
-    process.nextTick(function() {
+    setImmediate(function() {
       cli.publish(name, chunk);
       next();
     });


### PR DESCRIPTION
This fixes slowing down the eventloop under specific circumstances.
(no test cases yet, trying to implement a repeatable test)
